### PR TITLE
Ejecutar automerge con mi PAT

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -14,5 +14,5 @@ jobs:
     steps:
     - uses: alexwilson/enable-github-automerge-action@main
       with:
-        github-token: "${{ secrets.GITHUB_TOKEN }}"
+        github-token: "${{ secrets.GH_TOKEN }}"
         merge-method: "REBASE"


### PR DESCRIPTION
Permite que las acciones de push se ejecuten tras un automerge (si lo hace @github-actions no funciona para evitar recursion, gracias github, muy intuitivo).